### PR TITLE
Use Definitions in Loaders

### DIFF
--- a/resources/unite/prefixes.yaml
+++ b/resources/unite/prefixes.yaml
@@ -1,60 +1,60 @@
 - symbol: Y
   name: yotta
-  factor: 1e24,
+  factor: "1e24"
 - symbol: Z
   name: zetta
-  factor: 1e21,
+  factor: "1e21"
 - symbol: E
   name: exa
-  factor: 1e18,
+  factor: "1e18"
 - symbol: P
   name: peta
-  factor: 1e15,
+  factor: "1e15"
 - symbol: T
   name: tera
-  factor: 1e12,
+  factor: "1e12"
 - symbol: G
   name: giga
-  factor: 1e9,
+  factor: "1e9"
 - symbol: M
   name: mega
-  factor: 1e6,
+  factor: "1e6"
 - symbol: k
   name: kilo
-  factor: 1e3,
+  factor: "1e3"
 - symbol: h
   name: hecto
-  factor: 1e2,
+  factor: "1e2"
 - symbol: da
   name: deka
-  factor: 1e1,
+  factor: "1e1"
 - symbol: d
   name: deci
-  factor: 1e-1,
+  factor: "1e-1"
 - symbol: c
   name: centi
-  factor: 1e-2,
+  factor: "1e-2"
 - symbol: m
   name: milli
-  factor: 1e-6,
+  factor: "1e-6"
 - symbol: μ
   name: micro
-  factor: 1e-9,
+  factor: "1e-9"
 - symbol: n
   name: nano
-  factor: 1e-12,
+  factor: "1e-12"
 - symbol: p
   name: pico
-  factor: 1e-15,
+  factor: "1e-15"
 - symbol: f
   name: femto
-  factor: 1e-18,
+  factor: "1e-18"
 - symbol: a
   name: atto
-  factor: 1e-21,
+  factor: "1e-21"
 - symbol: z
   name: zepto
-  factor: 1e-24,
+  factor: "1e-24"
 - symbol: y
   name: yotto
-  factor: 1e-24,
+  factor: "1e-24"

--- a/resources/unite/prefixes.yaml
+++ b/resources/unite/prefixes.yaml
@@ -1,60 +1,60 @@
-Y:
+- symbol: Y
   name: yotta
   factor: 1e24,
-Z:
+- symbol: Z
   name: zetta
   factor: 1e21,
-E:
+- symbol: E
   name: exa
   factor: 1e18,
-P:
+- symbol: P
   name: peta
   factor: 1e15,
-T:
+- symbol: T
   name: tera
   factor: 1e12,
-G:
+- symbol: G
   name: giga
   factor: 1e9,
-M:
+- symbol: M
   name: mega
   factor: 1e6,
-k:
+- symbol: k
   name: kilo
   factor: 1e3,
-h:
+- symbol: h
   name: hecto
   factor: 1e2,
-da:
+- symbol: da
   name: deka
   factor: 1e1,
-d:
+- symbol: d
   name: deci
   factor: 1e-1,
-c:
+- symbol: c
   name: centi
   factor: 1e-2,
-m:
+- symbol: m
   name: milli
   factor: 1e-6,
-μ:
+- symbol: μ
   name: micro
   factor: 1e-9,
-n:
+- symbol: n
   name: nano
   factor: 1e-12,
-p:
+- symbol: p
   name: pico
   factor: 1e-15,
-f:
+- symbol: f
   name: femto
   factor: 1e-18,
-a:
+- symbol: a
   name: atto
   factor: 1e-21,
-z:
+- symbol: z
   name: zepto
   factor: 1e-24,
-y:
+- symbol: y
   name: yotto
   factor: 1e-24,

--- a/resources/unite/units.yaml
+++ b/resources/unite/units.yaml
@@ -10,6 +10,7 @@
   aliases: [lbs]
   kind: mass
   systems: [us, uk]
+  to: []
 - symbol: oz
   name: ounce|ounces
   aliases: []
@@ -20,3 +21,4 @@
   name: ton|tons
   aliases: []
   kind: mass
+  to: []

--- a/resources/unite/units.yaml
+++ b/resources/unite/units.yaml
@@ -4,7 +4,8 @@
   kind: mass
   systems: [si]
   to:
-    oz: 3.52739907e-2
+    - symbol: oz
+      factor: "0.0352739907"
 - symbol: lb
   name: "pound|pounds"
   aliases: [lbs]
@@ -17,7 +18,8 @@
   kind: mass
   systems: [us, uk]
   to:
-    g: 2.83495e1
+    - symbol: g
+      factor: "2.83495e1"
 - symbol: ton
   name: ton|tons
   aliases: []

--- a/resources/unite/units.yaml
+++ b/resources/unite/units.yaml
@@ -1,22 +1,22 @@
-g:
+- symbol: g
   name: gram|grams
   aliases: []
   kind: mass
   systems: [si]
   to:
     oz: 3.52739907e-2
-lb:
+- symbol: lb
   name: "pound|pounds"
   aliases: [lbs]
   kind: mass
   systems: [us, uk]
-oz:
+- symbol: oz
   name: ounce|ounces
   aliases: []
   kind: mass
   to:
     g: 2.83495e1
-ton:
+- symbol: ton
   name: ton|tons
   aliases: []
   kind: mass

--- a/resources/unite/units.yaml
+++ b/resources/unite/units.yaml
@@ -15,10 +15,12 @@
   name: ounce|ounces
   aliases: []
   kind: mass
+  systems: [us, uk]
   to:
     g: 2.83495e1
 - symbol: ton
   name: ton|tons
   aliases: []
   kind: mass
+  systems: [us, uk]
   to: []

--- a/src/Definitions/ConversionDefinition.php
+++ b/src/Definitions/ConversionDefinition.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Theutz\Unite\Definitions;
+
+class ConversionDefinition
+{
+    public function __construct(
+        public readonly string $symbol,
+        public readonly string $factor,
+    ) {
+    }
+}

--- a/src/Definitions/DefinitionLoader.php
+++ b/src/Definitions/DefinitionLoader.php
@@ -27,6 +27,6 @@ class DefinitionLoader
         $raw = $this->yaml->parseFile(config('unite.prefixes'));
 
         return collect($raw)
-            ->map([PrefixDefinition::class, 'make']);
+            ->map(fn ($data) => new PrefixDefinition(...$data));
     }
 }

--- a/src/Definitions/DefinitionLoader.php
+++ b/src/Definitions/DefinitionLoader.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace Theutz\Unite;
+namespace Theutz\Unite\Definitions;
 
 use Illuminate\Support\Collection;
 use Symfony\Component\Yaml\Yaml;
-use Theutz\Unite\Definitions\UnitDefinition;
 
-class Loader
+class DefinitionLoader
 {
     public function __construct(
         private Yaml $yaml,

--- a/src/Definitions/DefinitionLoader.php
+++ b/src/Definitions/DefinitionLoader.php
@@ -9,15 +9,24 @@ class DefinitionLoader
 {
     public function __construct(
         private Yaml $yaml,
-        private string $unitsPath,
     ) {
     }
 
     public function units(): Collection
     {
-        $raw = $this->yaml->parseFile($this->unitsPath);
+        $raw = $this->yaml->parseFile(
+            config('unite.units')
+        );
 
         return collect($raw)
-            ->map([UnitDefinition::class, 'make']);
+            ->map(fn ($data) => new UnitDefinition(...$data));
+    }
+
+    public function prefixes(): Collection
+    {
+        $raw = $this->yaml->parseFile(config('unite.prefixes'));
+
+        return collect($raw)
+            ->map([PrefixDefinition::class, 'make']);
     }
 }

--- a/src/Definitions/PrefixDefinition.php
+++ b/src/Definitions/PrefixDefinition.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Theutz\Unite\Definitions;
+
+class PrefixDefinition
+{
+    final public function __construct(
+        public readonly string $symbol,
+        public readonly string $name,
+        public readonly string $factor
+    ) {
+    }
+
+    public static function make(array $data)
+    {
+        return new static(
+            symbol: $data['symbol'],
+            name: $data['name'],
+            factor: $data['factor']
+        );
+    }
+}

--- a/src/Definitions/PrefixDefinition.php
+++ b/src/Definitions/PrefixDefinition.php
@@ -4,19 +4,10 @@ namespace Theutz\Unite\Definitions;
 
 class PrefixDefinition
 {
-    final public function __construct(
+    public function __construct(
         public readonly string $symbol,
         public readonly string $name,
         public readonly string $factor
     ) {
-    }
-
-    public static function make(array $data)
-    {
-        return new static(
-            symbol: $data['symbol'],
-            name: $data['name'],
-            factor: $data['factor']
-        );
     }
 }

--- a/src/Definitions/UnitDefinition.php
+++ b/src/Definitions/UnitDefinition.php
@@ -4,6 +4,11 @@ namespace Theutz\Unite\Definitions;
 
 use Illuminate\Support\Collection;
 
+/**
+ * @property Collection<int, string> $aliases
+ * @property Collection<int, string> $systems
+ * @property Collection<int, ConversionDefinition> $to
+ */
 class UnitDefinition
 {
     public readonly Collection $aliases;
@@ -22,6 +27,7 @@ class UnitDefinition
     ) {
         $this->aliases = collect($aliases);
         $this->systems = collect($systems);
-        $this->to = collect($to);
+        $this->to = collect($to)
+            ->map(fn ($data) => new ConversionDefinition(...$data));
     }
 }

--- a/src/Definitions/UnitDefinition.php
+++ b/src/Definitions/UnitDefinition.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Theutz\Unite\Definitions;
+
+class UnitDefinition
+{
+    final public function __construct(
+        public readonly string $symbol,
+        public readonly string $name,
+        public readonly array $aliases,
+        public readonly string $kind,
+        public readonly array $to
+    ) {}
+
+    public function make(array $data) {
+        return new static(
+            symbol: $data['symbol'],
+            name: $data['name'],
+            aliases: $data['aliases'],
+            kind: $data['kind'],
+            to: $data['to']
+        );
+    }
+}

--- a/src/Definitions/UnitDefinition.php
+++ b/src/Definitions/UnitDefinition.php
@@ -10,9 +10,11 @@ class UnitDefinition
         public readonly array $aliases,
         public readonly string $kind,
         public readonly array $to
-    ) {}
+    ) {
+    }
 
-    public static function make(array $data) {
+    public static function make(array $data)
+    {
         return new static(
             symbol: $data['symbol'],
             name: $data['name'],

--- a/src/Definitions/UnitDefinition.php
+++ b/src/Definitions/UnitDefinition.php
@@ -2,17 +2,26 @@
 
 namespace Theutz\Unite\Definitions;
 
-use ErrorException;
+use Illuminate\Support\Collection;
 
 class UnitDefinition
 {
+    public readonly Collection $aliases;
+
+    public readonly Collection $systems;
+
+    public readonly Collection $to;
+
     public function __construct(
         public readonly string $symbol,
         public readonly string $name,
-        public readonly array $aliases,
+        array $aliases,
         public readonly string $kind,
-        public readonly array $systems,
-        public readonly array $to
+        array $systems,
+        array $to
     ) {
+        $this->aliases = collect($aliases);
+        $this->systems = collect($systems);
+        $this->to = collect($to);
     }
 }

--- a/src/Definitions/UnitDefinition.php
+++ b/src/Definitions/UnitDefinition.php
@@ -2,25 +2,17 @@
 
 namespace Theutz\Unite\Definitions;
 
+use ErrorException;
+
 class UnitDefinition
 {
-    final public function __construct(
+    public function __construct(
         public readonly string $symbol,
         public readonly string $name,
         public readonly array $aliases,
         public readonly string $kind,
+        public readonly array $systems,
         public readonly array $to
     ) {
-    }
-
-    public static function make(array $data)
-    {
-        return new static(
-            symbol: $data['symbol'],
-            name: $data['name'],
-            aliases: $data['aliases'],
-            kind: $data['kind'],
-            to: $data['to']
-        );
     }
 }

--- a/src/Definitions/UnitDefinition.php
+++ b/src/Definitions/UnitDefinition.php
@@ -12,7 +12,7 @@ class UnitDefinition
         public readonly array $to
     ) {}
 
-    public function make(array $data) {
+    public static function make(array $data) {
         return new static(
             symbol: $data['symbol'],
             name: $data['name'],

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -2,7 +2,9 @@
 
 namespace Theutz\Unite;
 
+use Illuminate\Support\Collection;
 use Symfony\Component\Yaml\Yaml;
+use Theutz\Unite\Definitions\UnitDefinition;
 
 class Loader
 {
@@ -12,8 +14,11 @@ class Loader
     ) {
     }
 
-    public function units(): array
+    public function units(): Collection
     {
-        return $this->yaml->parseFile($this->unitsPath);
+        $raw = $this->yaml->parseFile($this->unitsPath);
+
+        return collect($raw)
+            ->map([UnitDefinition::class, 'make']);
     }
 }

--- a/src/Unite.php
+++ b/src/Unite.php
@@ -57,7 +57,7 @@ class Unite
     private function getUnit(string $unit): UnitDefinition
     {
         return collect($this->units->all())
-            ->filter(fn ($u) => $unit === $u->symbol || __('unite::units.' . $unit) === $u->symbol)
+            ->filter(fn ($u) => $unit === $u->symbol || __('unite::units.'.$unit) === $u->symbol)
             ->sole();
     }
 

--- a/src/Unite.php
+++ b/src/Unite.php
@@ -56,7 +56,7 @@ class Unite
     private function getUnit(string $unit): array
     {
         return collect($this->units->all())
-            ->filter(fn ($_, $symbol) => $unit === $symbol || __('unite::units.'.$unit) === $symbol)
+            ->filter(fn ($u) => $unit === $u['symbol'] || __('unite::units.' . $unit) === $u['symbol'])
             ->sole();
     }
 

--- a/src/Unite.php
+++ b/src/Unite.php
@@ -57,7 +57,7 @@ class Unite
     private function getUnit(string $unit): UnitDefinition
     {
         return collect($this->units->all())
-            ->filter(fn ($u) => $unit === $u->symbol || __('unite::units.'.$unit) === $u->symbol)
+            ->filter(fn ($u) => $unit === $u->symbol || __('unite::units.' . $unit) === $u->symbol)
             ->sole();
     }
 
@@ -65,6 +65,6 @@ class Unite
     {
         [, $toUnit] = $this->parse($unit);
 
-        return $this->unit->to[$toUnit->symbol];
+        return $this->unit->to->firstWhere('symbol', $toUnit->symbol)['factor'];
     }
 }

--- a/src/Unite.php
+++ b/src/Unite.php
@@ -57,7 +57,7 @@ class Unite
     private function getUnit(string $unit): UnitDefinition
     {
         return collect($this->units->all())
-            ->filter(fn ($u) => $unit === $u->symbol || __('unite::units.' . $unit) === $u->symbol)
+            ->filter(fn ($u) => $unit === $u->symbol || __('unite::units.'.$unit) === $u->symbol)
             ->sole();
     }
 
@@ -65,6 +65,6 @@ class Unite
     {
         [, $toUnit] = $this->parse($unit);
 
-        return $this->unit->to->firstWhere('symbol', $toUnit->symbol)['factor'];
+        return $this->unit->to->firstWhere('symbol', $toUnit->symbol)->factor;
     }
 }

--- a/src/Unite.php
+++ b/src/Unite.php
@@ -4,12 +4,13 @@ namespace Theutz\Unite;
 
 use Brick\Math\BigDecimal;
 use RuntimeException;
+use Theutz\Unite\Definitions\UnitDefinition;
 
 class Unite
 {
     private string $quantity;
 
-    private array $unit;
+    private UnitDefinition $unit;
 
     public function __construct(
         private Units $units
@@ -34,7 +35,7 @@ class Unite
     }
 
     /**
-     * @return array{0: string, 1: array}
+     * @return array{0: string, 1: UnitDefinition}
      */
     private function parse(string $string): array
     {
@@ -53,18 +54,17 @@ class Unite
         return [$quantity, $this->getUnit($unit)];
     }
 
-    private function getUnit(string $unit): array
+    private function getUnit(string $unit): UnitDefinition
     {
         return collect($this->units->all())
-            ->filter(fn ($u) => $unit === $u['symbol'] || __('unite::units.' . $unit) === $u['symbol'])
+            ->filter(fn ($u) => $unit === $u->symbol || __('unite::units.' . $unit) === $u->symbol)
             ->sole();
     }
 
     private function getConversionFactor(string $unit): string
     {
         [, $toUnit] = $this->parse($unit);
-        ['symbol' => $symbol] = $toUnit;
 
-        return $this->unit['to'][$symbol];
+        return $this->unit->to[$toUnit->symbol];
     }
 }

--- a/src/UniteServiceProvider.php
+++ b/src/UniteServiceProvider.php
@@ -8,6 +8,8 @@ use Theutz\Unite\Definitions\DefinitionLoader;
 
 class UniteServiceProvider extends PackageServiceProvider
 {
+    public $singletons = [DefinitionLoader::class];
+
     public function configurePackage(Package $package): void
     {
         /*
@@ -19,18 +21,5 @@ class UniteServiceProvider extends PackageServiceProvider
             ->name('laravel-unite')
             ->hasConfigFile()
             ->hasTranslations();
-    }
-
-    public function packageRegistered(): void
-    {
-        $this->registerLoader();
-    }
-
-    private function registerLoader(): void
-    {
-        $this->app->singleton(DefinitionLoader::class);
-        $this->app->when(DefinitionLoader::class)
-            ->needs('$unitsPath')
-            ->giveConfig('unite.units');
     }
 }

--- a/src/UniteServiceProvider.php
+++ b/src/UniteServiceProvider.php
@@ -4,6 +4,7 @@ namespace Theutz\Unite;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Theutz\Unite\Definitions\DefinitionLoader;
 
 class UniteServiceProvider extends PackageServiceProvider
 {
@@ -27,8 +28,8 @@ class UniteServiceProvider extends PackageServiceProvider
 
     private function registerLoader(): void
     {
-        $this->app->singleton(Loader::class);
-        $this->app->when(Loader::class)
+        $this->app->singleton(DefinitionLoader::class);
+        $this->app->when(DefinitionLoader::class)
             ->needs('$unitsPath')
             ->giveConfig('unite.units');
     }

--- a/src/Units.php
+++ b/src/Units.php
@@ -3,13 +3,14 @@
 namespace Theutz\Unite;
 
 use Illuminate\Support\Collection;
+use Theutz\Unite\Definitions\DefinitionLoader;
 
 class Units
 {
     const PLURAL_SEPARATOR = '|';
 
     public function __construct(
-        private Loader $loader
+        private DefinitionLoader $loader
     ) {
     }
 

--- a/src/Units.php
+++ b/src/Units.php
@@ -2,6 +2,8 @@
 
 namespace Theutz\Unite;
 
+use Illuminate\Support\Collection;
+
 class Units
 {
     const PLURAL_SEPARATOR = '|';
@@ -11,7 +13,7 @@ class Units
     ) {
     }
 
-    public function all(): array
+    public function all(): Collection
     {
         return $this->loader->units();
     }
@@ -21,18 +23,18 @@ class Units
         return $this->toLangAliases($this->all());
     }
 
-    private function toLangAliases(array $units): array
+    private function toLangAliases(Collection $units): array
     {
-        return collect($units)
+        return $units
             ->reduce(function ($carry, $unit) {
-                $carry->put($unit['symbol'], $unit['name']);
+                $carry->put($unit->symbol, $unit->name);
 
-                collect($unit['aliases'])
-                    ->merge($unit['name'])
+                collect($unit->aliases)
+                    ->merge($unit->name)
                     ->each(
                         fn ($nameDef) => str($nameDef)
                             ->explode(self::PLURAL_SEPARATOR)
-                            ->each(fn ($name) => $carry->put($name, $unit['symbol']))
+                            ->each(fn ($name) => $carry->put($name, $unit->symbol))
                     );
 
                 return $carry;

--- a/src/Units.php
+++ b/src/Units.php
@@ -13,9 +13,7 @@ class Units
 
     public function all(): array
     {
-        return collect($this->loader->units())
-            ->map(fn ($item, $key) => [...$item, 'symbol' => $key])
-            ->all();
+        return $this->loader->units();
     }
 
     public function generateLang(): array
@@ -26,15 +24,15 @@ class Units
     private function toLangAliases(array $units): array
     {
         return collect($units)
-            ->reduce(function ($carry, $unit, $symbol) {
-                $carry->put($symbol, $unit['name']);
+            ->reduce(function ($carry, $unit) {
+                $carry->put($unit['symbol'], $unit['name']);
 
                 collect($unit['aliases'])
                     ->merge($unit['name'])
                     ->each(
                         fn ($nameDef) => str($nameDef)
                             ->explode(self::PLURAL_SEPARATOR)
-                            ->each(fn ($name) => $carry->put($name, $symbol))
+                            ->each(fn ($name) => $carry->put($name, $unit['symbol']))
                     );
 
                 return $carry;

--- a/tests/Feature/DefinitionLoaderTest.php
+++ b/tests/Feature/DefinitionLoaderTest.php
@@ -8,23 +8,18 @@ use Theutz\Unite\Definitions\DefinitionLoader;
 use Theutz\Unite\Definitions\UnitDefinition;
 
 it('loads the units', function () {
-    $expected = [
-        [
-            'symbol' => 'g',
-            'name' => 'gram|grams',
-            'aliases' => [],
-            'kind' => 'mass',
-            'systems' => ['si'],
-            'to' => [],
-        ],
-    ];
-    mock(Yaml::class)
-        ->shouldReceive('parseFile')
-        ->once()
-        ->andReturn($expected);
     $sut = app(DefinitionLoader::class);
 
     $result = $sut->units();
 
-    expect($result)->toMatchArray([UnitDefinition::make($expected[0])]);
+    expect($result->firstWhere('symbol', 'g'))->toEqual(
+        new UnitDefinition(
+            symbol: 'g',
+            name: 'gram|grams',
+            aliases: [],
+            kind: 'mass',
+            systems: ['si'],
+            to: ['oz' => '0.0352739907']
+        )
+    );
 });

--- a/tests/Feature/DefinitionLoaderTest.php
+++ b/tests/Feature/DefinitionLoaderTest.php
@@ -4,6 +4,7 @@ namespace Theutz\Unite;
 
 use function Pest\Laravel\mock;
 use Symfony\Component\Yaml\Yaml;
+use Theutz\Unite\Definitions\DefinitionLoader;
 use Theutz\Unite\Definitions\UnitDefinition;
 
 it('loads the units', function () {
@@ -21,7 +22,7 @@ it('loads the units', function () {
         ->shouldReceive('parseFile')
         ->once()
         ->andReturn($expected);
-    $sut = app(Loader::class);
+    $sut = app(DefinitionLoader::class);
 
     $result = $sut->units();
 

--- a/tests/Feature/DefinitionLoaderTest.php
+++ b/tests/Feature/DefinitionLoaderTest.php
@@ -2,15 +2,16 @@
 
 namespace Theutz\Unite;
 
-use function Pest\Laravel\mock;
-use Symfony\Component\Yaml\Yaml;
 use Theutz\Unite\Definitions\DefinitionLoader;
+use Theutz\Unite\Definitions\PrefixDefinition;
 use Theutz\Unite\Definitions\UnitDefinition;
 
-it('loads the units', function () {
-    $sut = app(DefinitionLoader::class);
+beforeEach(function () {
+    $this->sut = app(DefinitionLoader::class);
+});
 
-    $result = $sut->units();
+it('loads the units', function () {
+    $result = $this->sut->units();
 
     expect($result->firstWhere('symbol', 'g'))->toEqual(
         new UnitDefinition(
@@ -20,6 +21,18 @@ it('loads the units', function () {
             kind: 'mass',
             systems: ['si'],
             to: ['oz' => '0.0352739907']
+        )
+    );
+});
+
+it('loads the prefixes', function () {
+    $result = $this->sut->prefixes();
+
+    expect($result->firstWhere('symbol', 'k'))->toEqual(
+        new PrefixDefinition(
+            symbol: 'k',
+            name: 'kilo',
+            factor: '1e3'
         )
     );
 });

--- a/tests/Feature/DefinitionLoaderTest.php
+++ b/tests/Feature/DefinitionLoaderTest.php
@@ -20,7 +20,9 @@ it('loads the units', function () {
             aliases: [],
             kind: 'mass',
             systems: ['si'],
-            to: ['oz' => '0.0352739907']
+            to: [
+                ['symbol' => 'oz', 'factor' => '0.0352739907'],
+            ]
         )
     );
 });

--- a/tests/Feature/LoaderTest.php
+++ b/tests/Feature/LoaderTest.php
@@ -6,7 +6,12 @@ use function Pest\Laravel\mock;
 use Symfony\Component\Yaml\Yaml;
 
 it('loads the units', function () {
-    $expected = ['g' => ['name' => 'gram|grams']];
+    $expected = [
+        [
+            'symbol' => 'g',
+            'name' => 'gram|grams'
+        ]
+    ];
     mock(Yaml::class)
         ->shouldReceive('parseFile')
         ->once()

--- a/tests/Feature/LoaderTest.php
+++ b/tests/Feature/LoaderTest.php
@@ -4,13 +4,18 @@ namespace Theutz\Unite;
 
 use function Pest\Laravel\mock;
 use Symfony\Component\Yaml\Yaml;
+use Theutz\Unite\Definitions\UnitDefinition;
 
 it('loads the units', function () {
     $expected = [
         [
             'symbol' => 'g',
-            'name' => 'gram|grams'
-        ]
+            'name' => 'gram|grams',
+            'aliases' => [],
+            'kind' => 'mass',
+            'systems' => ['si'],
+            'to' => [],
+        ],
     ];
     mock(Yaml::class)
         ->shouldReceive('parseFile')
@@ -20,5 +25,5 @@ it('loads the units', function () {
 
     $result = $sut->units();
 
-    expect($result)->toMatchArray($expected);
+    expect($result)->toMatchArray([UnitDefinition::make($expected[0])]);
 });

--- a/tests/Feature/UnitsTest.php
+++ b/tests/Feature/UnitsTest.php
@@ -11,7 +11,8 @@ it('produces the units', function () {
         ->withSomeOfArgs('filename')
         ->once()
         ->andReturn([
-            'A' => [
+            [
+                'symbol' => 'A',
                 'name' => 'ampere|amperes',
                 'aliases' => ['amp|amps'],
             ],

--- a/tests/Feature/UnitsTest.php
+++ b/tests/Feature/UnitsTest.php
@@ -1,31 +1,11 @@
 <?php
 
-use function Pest\Laravel\mock;
-use Symfony\Component\Yaml\Yaml;
 use Theutz\Unite\Units;
 
 it('produces the units', function () {
-    config(['unite.units' => 'filename']);
-    mock(Yaml::class)
-        ->shouldReceive('parseFile')
-        ->withSomeOfArgs('filename')
-        ->once()
-        ->andReturn([
-            [
-                'symbol' => 'A',
-                'name' => 'ampere|amperes',
-                'aliases' => ['amp|amps'],
-            ],
-        ])
-        ->getMock();
-
     $result = app(Units::class)->generateLang();
 
     expect($result)->toMatchArray([
-        'A' => 'ampere|amperes',
-        'ampere' => 'A',
-        'amperes' => 'A',
-        'amp' => 'A',
-        'amps' => 'A',
+        'g' => 'gram|grams',
     ]);
 });


### PR DESCRIPTION
- Refactor unit yaml
- Refactor prefixes
- Setup definitions
- Apply definitions
- Rename Loader to DefinitionLoader
- Setup typesafe definitions
- Simpler singleton for loader
- Test loading prefix defs
- Don't use keys for the `to` map
- Setup conversion definition
