### PR TITLE
Generate SI Prefixes

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,10 +25,10 @@ parameters:
             reportUnmatched: false
             paths:
                 - tests/*
-        # -
-        #     message: '#Call to an undefined method Pest\\Expectation<Closure>::throws\(\)#'
-        #     paths:
-        #         - tests/*
+        -
+            message: '#Call to an undefined method Pest\\Expectation<Closure>::[\w\-_]*\(\)#'
+            paths:
+                - tests/*
     #checkOctaneCompatibility: true
     #checkModelProperties: true
     checkMissingIterableValueType: false

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,10 +20,11 @@ parameters:
             reportUnmatched: false
             paths:
                 - tests/*
-        # -
-        #     message: '#Access to an undefined property Pest\\Expectation\|Pest\\Support\\Extendable::\$[\w\-_]#'
-        #     paths:
-        #         - tests/*
+        -
+            message: '#Call to an undefined method Pest\\Expectation\|Pest\\Support\\Extendable::[\w\-_]*\(\)#'
+            reportUnmatched: false
+            paths:
+                - tests/*
         # -
         #     message: '#Call to an undefined method Pest\\Expectation<Closure>::throws\(\)#'
         #     paths:

--- a/src/Collections/UnitsCollection.php
+++ b/src/Collections/UnitsCollection.php
@@ -2,8 +2,39 @@
 
 namespace Theutz\Unite\Collections;
 
+use Countable;
 use Illuminate\Support\Collection;
+use IteratorAggregate;
+use Theutz\Unite\Definitions\DefinitionLoader;
+use Traversable;
 
-class UnitsCollection extends Collection
+/**
+ * @mixin Collection
+ */
+class UnitsCollection implements IteratorAggregate, Countable
 {
+    private Collection $collection;
+
+    public function __construct(
+        DefinitionLoader $loader
+    ) {
+        $this->collection = collect($loader->units());
+    }
+
+    public function getIterator(): Traversable
+    {
+        return $this->collection;
+    }
+
+    public function count(): int
+    {
+        return $this->collection->count();
+    }
+
+    public function __call($name, $args)
+    {
+        if (method_exists($this->collection, $name)) {
+            return $this->collection->$name(...$args);
+        }
+    }
 }

--- a/src/Collections/UnitsCollection.php
+++ b/src/Collections/UnitsCollection.php
@@ -6,6 +6,7 @@ use Countable;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
 use Theutz\Unite\Definitions\DefinitionLoader;
+use Theutz\Unite\Definitions\UnitDefinition;
 use Traversable;
 
 /**
@@ -16,9 +17,11 @@ class UnitsCollection implements IteratorAggregate, Countable
     private Collection $collection;
 
     public function __construct(
-        DefinitionLoader $loader
+        private DefinitionLoader $loader
     ) {
-        $this->collection = collect($loader->units());
+        $this->collection = $this->generateSiUnits(
+            $loader->units()
+        );
     }
 
     public function getIterator(): Traversable
@@ -36,5 +39,46 @@ class UnitsCollection implements IteratorAggregate, Countable
         if (method_exists($this->collection, $name)) {
             return $this->collection->$name(...$args);
         }
+    }
+
+    private function generateSiUnits(Collection $units): Collection
+    {
+        return $units->reduce(
+            function (Collection $carry, UnitDefinition $unit) {
+                $carry->push($unit);
+
+                if ($unit->systems->contains('si')) {
+                    $this->loader->prefixes()
+                        ->each(function ($prefix) use ($unit, $carry) {
+                            $aliases = $unit->aliases->map(fn ($alias) => $this->prefixPluralizedString($alias, $prefix->name));
+                            $to = [];
+
+                            $prefixedUnit = new UnitDefinition(
+                                symbol: $prefix->symbol . $unit->symbol,
+                                name: $this->prefixPluralizedString($unit->name, $prefix->name),
+                                kind: $unit->kind,
+                                systems: $unit->systems,
+                                aliases: $aliases,
+                                to: $to,
+                            );
+
+                            $carry->push($prefixedUnit);
+                        });
+                }
+
+                return $carry;
+            },
+            collect()
+        );
+    }
+
+    private function prefixPluralizedString(string $base, string $prefix): string
+    {
+        $sep = config('unite.plural_separator');
+
+        return str($base)
+            ->explode($sep)
+            ->map(fn ($piece) => $prefix . $piece)
+            ->join($sep);
     }
 }

--- a/src/Collections/UnitsCollection.php
+++ b/src/Collections/UnitsCollection.php
@@ -2,9 +2,11 @@
 
 namespace Theutz\Unite\Collections;
 
+use Brick\Math\BigDecimal;
 use Countable;
 use Illuminate\Support\Collection;
 use IteratorAggregate;
+use Theutz\Unite\Definitions\ConversionDefinition;
 use Theutz\Unite\Definitions\DefinitionLoader;
 use Theutz\Unite\Definitions\PrefixDefinition;
 use Theutz\Unite\Definitions\UnitDefinition;
@@ -65,12 +67,17 @@ class UnitsCollection implements IteratorAggregate, Countable
     private function makePrefixedUnit(PrefixDefinition $prefix, UnitDefinition $unit): UnitDefinition
     {
         return new UnitDefinition(
-            symbol: $prefix->symbol . $unit->symbol,
+            symbol: $prefix->symbol.$unit->symbol,
             name: $this->prefixPluralizedString($unit->name, $prefix->name),
             kind: $unit->kind,
             systems: $unit->systems,
-            aliases: $unit->aliases->map(fn ($alias) => $this->prefixPluralizedString($alias, $prefix->name)),
-            to: [],
+            aliases: $unit->aliases->map(
+                fn ($alias) => $this->prefixPluralizedString($alias, $prefix->name)
+            ),
+            to: $unit->to->map(fn (ConversionDefinition $conv) => new ConversionDefinition(
+                symbol: $conv->symbol,
+                factor: str(BigDecimal::of($conv->factor)->multipliedBy($prefix->factor))->rtrim(0)
+            )),
         );
     }
 
@@ -80,7 +87,7 @@ class UnitsCollection implements IteratorAggregate, Countable
 
         return str($base)
             ->explode($sep)
-            ->map(fn ($piece) => $prefix . $piece)
+            ->map(fn ($piece) => $prefix.$piece)
             ->join($sep);
     }
 }

--- a/src/Collections/UnitsCollection.php
+++ b/src/Collections/UnitsCollection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Theutz\Unite\Collections;
+
+use Illuminate\Support\Collection;
+
+class UnitsCollection extends Collection
+{
+}

--- a/src/Definitions/ConversionDefinition.php
+++ b/src/Definitions/ConversionDefinition.php
@@ -2,11 +2,20 @@
 
 namespace Theutz\Unite\Definitions;
 
-class ConversionDefinition
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+
+class ConversionDefinition implements IteratorAggregate
 {
     public function __construct(
         public readonly string $symbol,
         public readonly string $factor,
     ) {
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator((array) $this);
     }
 }

--- a/src/Definitions/UnitDefinition.php
+++ b/src/Definitions/UnitDefinition.php
@@ -20,10 +20,10 @@ class UnitDefinition
     public function __construct(
         public readonly string $symbol,
         public readonly string $name,
-        array $aliases,
+        Collection|array $aliases,
         public readonly string $kind,
-        array $systems,
-        array $to
+        Collection|array $systems,
+        Collection|array $to
     ) {
         $this->aliases = collect($aliases);
         $this->systems = collect($systems);

--- a/src/UniteServiceProvider.php
+++ b/src/UniteServiceProvider.php
@@ -4,11 +4,15 @@ namespace Theutz\Unite;
 
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Theutz\Unite\Collections\UnitsCollection;
 use Theutz\Unite\Definitions\DefinitionLoader;
 
 class UniteServiceProvider extends PackageServiceProvider
 {
-    public $singletons = [DefinitionLoader::class];
+    public $singletons = [
+        DefinitionLoader::class,
+        UnitsCollection::class,
+    ];
 
     public function configurePackage(Package $package): void
     {

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -4,4 +4,8 @@ namespace Theutz\Unite\Collections;
 
 it('should load', function () {
     $sut = app(UnitsCollection::class);
+
+    expect($sut)->toBeIterable();
+    expect(count($sut))->toBeGreaterThanOrEqual(1);
+    expect($sut->where('symbol', 'g'))->toHaveCount(1);
 });

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -3,5 +3,5 @@
 namespace Theutz\Unite\Collections;
 
 it('should load', function () {
-    $sut = app(UnitCollection::class);
+    $sut = app(UnitsCollection::class);
 });

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -2,6 +2,7 @@
 
 namespace Theutz\Unite\Collections;
 
+use Theutz\Unite\Definitions\ConversionDefinition;
 use Theutz\Unite\Definitions\UnitDefinition;
 
 beforeEach(fn () => $this->sut = app(UnitsCollection::class));
@@ -27,5 +28,12 @@ it('should generate prefixed units')
     ->toMatchObject((object) [
         'symbol' => 'kg',
         'name' => 'kilogram|kilograms',
-        'aliases' => collect()
+        'aliases' => collect(),
+        'kind' => 'mass',
+        'to' => collect([
+            new ConversionDefinition(
+                symbol: 'oz',
+                factor: '35.2739907'
+            ),
+        ]),
     ]);

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -7,8 +7,10 @@ use Theutz\Unite\Definitions\UnitDefinition;
 
 beforeEach(fn () => $this->sut = app(UnitsCollection::class));
 
+$sut = fn () => $this->sut;
+
 it('should be iterable')
-    ->expect(fn () => $this->sut)
+    ->expect($sut)
     ->toBeIterable();
 
 it('should be countable')
@@ -16,13 +18,13 @@ it('should be countable')
     ->toBeGreaterThanOrEqual(1);
 
 it('should be a collection of unit definitions')
-    ->expect(fn () => $this->sut)
+    ->expect($sut)
     ->where('symbol', 'g')
     ->sole()
     ->toBeInstanceOf(UnitDefinition::class);
 
 it('should generate prefixed units')
-    ->expect(fn () => $this->sut)
+    ->expect($sut)
     ->where('symbol', 'kg')
     ->first()
     ->toMatchObject((object) [
@@ -37,3 +39,6 @@ it('should generate prefixed units')
             ),
         ]),
     ]);
+
+// it('should generate lang entries')
+//     ->expect($sut);

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -19,3 +19,13 @@ it('should be a collection of unit definitions')
     ->where('symbol', 'g')
     ->sole()
     ->toBeInstanceOf(UnitDefinition::class);
+
+it('should generate prefixed units')
+    ->expect(fn () => $this->sut)
+    ->where('symbol', 'kg')
+    ->first()
+    ->toMatchObject((object) [
+        'symbol' => 'kg',
+        'name' => 'kilogram|kilograms',
+        'aliases' => collect()
+    ]);

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -2,10 +2,20 @@
 
 namespace Theutz\Unite\Collections;
 
-it('should load', function () {
-    $sut = app(UnitsCollection::class);
+use Theutz\Unite\Definitions\UnitDefinition;
 
-    expect($sut)->toBeIterable();
-    expect(count($sut))->toBeGreaterThanOrEqual(1);
-    expect($sut->where('symbol', 'g'))->toHaveCount(1);
-});
+beforeEach(fn () => $this->sut = app(UnitsCollection::class));
+
+it('should be iterable')
+    ->expect(fn () => $this->sut)
+    ->toBeIterable();
+
+it('should be countable')
+    ->expect(fn () => count($this->sut))
+    ->toBeGreaterThanOrEqual(1);
+
+it('should be a collection of unit definitions')
+    ->expect(fn () => $this->sut)
+    ->where('symbol', 'g')
+    ->sole()
+    ->toBeInstanceOf(UnitDefinition::class);

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -40,5 +40,11 @@ it('should generate prefixed units')
         ]),
     ]);
 
-// it('should generate lang entries')
-//     ->expect($sut);
+it('should generate lang entries')
+    ->expect($sut)
+    ->toLang()
+    ->toMatchArray([
+        'g' => 'gram|grams',
+        'gram' => 'g',
+        'grams' => 'g',
+    ]);

--- a/tests/Feature/UnitCollectionTest.php
+++ b/tests/Feature/UnitCollectionTest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Theutz\Unite\Collections;
+
+it('should load', function () {
+    $sut = app(UnitCollection::class);
+});


### PR DESCRIPTION
Setup units collection so that it can generate prefixes

- Write test
- Setup basic class
- Proxy calls to the collection
- Make a unit collection
- Make strings prefixed
- Refactor a bit
- Finish copying over conversion
- Refactor test
- Push prefixes to array
